### PR TITLE
Fix params to reset chart of account in account.config.settings

### DIFF
--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -161,9 +161,7 @@ class ResCompany(models.Model):
             pass
 
         try:
-            self.env['account.full.reconcile'].search([]
-                #[('company_id', '=', self.id)]
-            ).unlink()
+            self.env['account.full.reconcile'].search([]).unlink()
         except KeyError:
             pass
 
@@ -176,8 +174,8 @@ class ResCompany(models.Model):
             'chart_template_id': False,
         })
         self.chart_template_id = False
+
         if settings_id:
             settings_id.execute()
 
         return True
-

--- a/account_reset_chart/models/res_company.py
+++ b/account_reset_chart/models/res_company.py
@@ -161,8 +161,8 @@ class ResCompany(models.Model):
             pass
 
         try:
-            self.env['account.full.reconcile'].search(
-                [('company_id', '=', self.id)]
+            self.env['account.full.reconcile'].search([]
+                #[('company_id', '=', self.id)]
             ).unlink()
         except KeyError:
             pass
@@ -172,6 +172,12 @@ class ResCompany(models.Model):
         )
         settings_id.write({
             'has_chart_of_accounts': False,
-            'expects_chart_of_accounts': False,
+            'expects_chart_of_accounts': True,
+            'chart_template_id': False,
         })
+        self.chart_template_id = False
+        if settings_id:
+            settings_id.execute()
+
         return True
+


### PR DESCRIPTION
to be able to bypass `addons/account/models/res_config.py` raise on line 237